### PR TITLE
cmd/entc: add support for generate.go when default target argument is not applied

### DIFF
--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -194,25 +194,25 @@ func createDir(target string) error {
 	if err := os.MkdirAll(target, os.ModePerm); err != nil {
 		return fmt.Errorf("creating schema directory: %w", err)
 	}
-	if err := ioutil.WriteFile(target+"/../generate.go", []byte(getGenerateFileData(target)), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(target, "/../generate.go"), getGenerateFileData(target), 0644); err != nil {
 		return fmt.Errorf("creating generate.go file: %w", err)
 	}
 	return nil
 }
 
 // ent/generate.go file used for "go generate" command.
-func getGenerateFileData(target string) string {
+func getGenerateFileData(target string) []byte {
 	pathArr := strings.Split(target, "/")
 
 	var sb strings.Builder
 	sb.Grow(32)
 
 	sb.WriteString("package ent\n\n")
-	sb.WriteString("//go:generate go run github.com/facebookincubator/ent/cmd/entc generate ")
-	sb.WriteString("./" + pathArr[len(pathArr)-1])
+	sb.WriteString("//go:generate go run github.com/facebookincubator/ent/cmd/entc generate ./")
+	sb.WriteString(pathArr[len(pathArr)-1])
 	sb.WriteString("\n")
 
-	return sb.String()
+	return []byte(sb.String())
 }
 
 // schema template for the "init" command.

--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -202,14 +202,14 @@ func createDir(target string) error {
 
 // ent/generate.go file used for "go generate" command.
 func getGenerateFileData(target string) []byte {
-	pathArr := strings.Split(target, "/")
-
 	var sb strings.Builder
 	sb.Grow(32)
 
-	sb.WriteString("package ent\n\n")
+	sb.WriteString("package ")
+	sb.WriteString(filepath.Base(filepath.Dir(target)))
+	sb.WriteString("\n\n")
 	sb.WriteString("//go:generate go run github.com/facebookincubator/ent/cmd/entc generate ./")
-	sb.WriteString(pathArr[len(pathArr)-1])
+	sb.WriteString(filepath.Base(target))
 	sb.WriteString("\n")
 
 	return []byte(sb.String())

--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -194,7 +194,7 @@ func createDir(target string) error {
 	if err := os.MkdirAll(target, os.ModePerm); err != nil {
 		return fmt.Errorf("creating schema directory: %w", err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(target, "/../generate.go"), getGenerateFileData(target), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(filepath.Dir(target), "generate.go"), getGenerateFileData(target), 0644); err != nil {
 		return fmt.Errorf("creating generate.go file: %w", err)
 	}
 	return nil

--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -194,13 +194,25 @@ func createDir(target string) error {
 	if err := os.MkdirAll(target, os.ModePerm); err != nil {
 		return fmt.Errorf("creating schema directory: %w", err)
 	}
-	if target != defaultSchema {
-		return nil
-	}
-	if err := ioutil.WriteFile("ent/generate.go", []byte(genFile), 0644); err != nil {
+	if err := ioutil.WriteFile(target+"/../generate.go", []byte(getGenerateFileData(target)), 0644); err != nil {
 		return fmt.Errorf("creating generate.go file: %w", err)
 	}
 	return nil
+}
+
+// ent/generate.go file used for "go generate" command.
+func getGenerateFileData(target string) string {
+	pathArr := strings.Split(target, "/")
+
+	var sb strings.Builder
+	sb.Grow(32)
+
+	sb.WriteString("package ent\n\n")
+	sb.WriteString("//go:generate go run github.com/facebookincubator/ent/cmd/entc generate ")
+	sb.WriteString("./" + pathArr[len(pathArr)-1])
+	sb.WriteString("\n")
+
+	return sb.String()
 }
 
 // schema template for the "init" command.
@@ -228,8 +240,6 @@ func ({{ . }}) Edges() []ent.Edge {
 const (
 	// default schema package path.
 	defaultSchema = "ent/schema"
-	// ent/generate.go file used for "go generate" command.
-	genFile = "package ent\n\n//go:generate go run github.com/facebookincubator/ent/cmd/entc generate ./schema\n"
 )
 
 // examples formats the given examples to the cli.

--- a/cmd/entc/entc_test.go
+++ b/cmd/entc/entc_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,25 +36,26 @@ func TestCmd(t *testing.T) {
 }
 
 func TestCmdWithTargetArg(t *testing.T) {
-	targetBasePath := "entity"
-	targetSchemaFolderName := "schema"
+	basePath := "entity"
+	schemaDir := "schema"
+	absPath, _ := filepath.Abs(filepath.Join(basePath, "/", schemaDir))
 
-	defer os.RemoveAll(targetBasePath)
-	cmd := exec.Command("go", "run", "github.com/facebookincubator/ent/cmd/entc", "init", "--target", targetBasePath+"/"+targetSchemaFolderName, "User")
+	defer os.RemoveAll(basePath)
+	cmd := exec.Command("go", "run", "github.com/facebookincubator/ent/cmd/entc", "init", "--target", absPath, "User")
 	stderr := bytes.NewBuffer(nil)
 	cmd.Stderr = stderr
 	require.NoError(t, cmd.Run(), stderr.String())
 
-	_, err := os.Stat(targetBasePath + "/generate.go")
+	_, err := os.Stat(filepath.Join(basePath, "/generate.go"))
 	require.NoError(t, err)
-	_, err = os.Stat(targetBasePath + "/" + targetSchemaFolderName + "/user.go")
+	_, err = os.Stat(filepath.Join(basePath, "/", schemaDir, "/user.go"))
 	require.NoError(t, err)
 
-	cmd = exec.Command("go", "run", "github.com/facebookincubator/ent/cmd/entc", "generate", "./"+targetBasePath+"/"+targetSchemaFolderName)
+	cmd = exec.Command("go", "run", "github.com/facebookincubator/ent/cmd/entc", "generate", absPath)
 	stderr = bytes.NewBuffer(nil)
 	cmd.Stderr = stderr
 	require.NoError(t, cmd.Run(), stderr.String())
 
-	_, err = os.Stat(targetBasePath + "/user.go")
+	_, err = os.Stat(filepath.Join(basePath, "/user.go"))
 	require.NoError(t, err)
 }

--- a/cmd/entc/entc_test.go
+++ b/cmd/entc/entc_test.go
@@ -33,3 +33,27 @@ func TestCmd(t *testing.T) {
 	_, err = os.Stat("ent/user.go")
 	require.NoError(t, err)
 }
+
+func TestCmdWithTargetArg(t *testing.T) {
+	targetBasePath := "entity"
+	targetSchemaFolderName := "schema"
+
+	defer os.RemoveAll(targetBasePath)
+	cmd := exec.Command("go", "run", "github.com/facebookincubator/ent/cmd/entc", "init", "--target", targetBasePath+"/"+targetSchemaFolderName, "User")
+	stderr := bytes.NewBuffer(nil)
+	cmd.Stderr = stderr
+	require.NoError(t, cmd.Run(), stderr.String())
+
+	_, err := os.Stat(targetBasePath + "/generate.go")
+	require.NoError(t, err)
+	_, err = os.Stat(targetBasePath + "/" + targetSchemaFolderName + "/user.go")
+	require.NoError(t, err)
+
+	cmd = exec.Command("go", "run", "github.com/facebookincubator/ent/cmd/entc", "generate", "./"+targetBasePath+"/"+targetSchemaFolderName)
+	stderr = bytes.NewBuffer(nil)
+	cmd.Stderr = stderr
+	require.NoError(t, cmd.Run(), stderr.String())
+
+	_, err = os.Stat(targetBasePath + "/user.go")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Resolve https://github.com/facebookincubator/ent/issues/566.