### PR TITLE
schema/edge: fix edge annotations with to/from builders

### DIFF
--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -190,7 +190,7 @@ func (g *Graph) addEdges(schema *load.Schema) {
 				Unique:      ref.Unique,
 				Optional:    !ref.Required,
 				StructTag:   ref.Tag,
-				Annotations: e.Annotations,
+				Annotations: ref.Annotations,
 			})
 		default:
 			panic(graphError{"edge must be either an assoc or inverse edge"})

--- a/entc/gen/graph_test.go
+++ b/entc/gen/graph_test.go
@@ -57,6 +57,7 @@ var (
 			{Name: "t1_o2m", Type: "T1", RefName: "t2_m2o", Inverse: true},
 			{Name: "t1_m2o", Type: "T1", RefName: "t2_o2m", Unique: true, Inverse: true},
 			{Name: "t1_m2m", Type: "T1", RefName: "t2_m2m", Inverse: true},
+			{Name: "t2_m2m_from", Type: "T2", Ref: &load.Edge{Name: "t2_m2m_to", Type: "T2", Annotations: dict("GQL", map[string]string{"Name": "To"})}, Inverse: true, Annotations: dict("GQL", map[string]string{"Name": "From"})},
 		},
 	}
 )
@@ -118,6 +119,11 @@ func TestNewGraph(t *testing.T) {
 	require.True(e1.IsInverse())
 	require.Equal("t2", e1.Inverse)
 	require.Equal(graph.Nodes[0], e1.Type)
+
+	require.Equal("t2_m2m_from", t2.Edges[5].Name)
+	require.Equal("t2_m2m_to", t2.Edges[6].Name)
+	require.Equal(map[string]string{"Name": "From"}, t2.Edges[5].Annotations["GQL"])
+	require.Equal(map[string]string{"Name": "To"}, t2.Edges[6].Annotations["GQL"])
 }
 
 func TestNewGraphRequiredLoop(t *testing.T) {

--- a/entc/load/schema_test.go
+++ b/entc/load/schema_test.go
@@ -66,6 +66,10 @@ func (User) Edges() []ent.Edge {
 			Unique().
 			StorageKey(edge.Column("user_parent_id")).
 			From("children"),
+		edge.To("following", User.Type).
+			Annotations(&OrderConfig{FieldName: "following"}).
+			From("followers").
+			Annotations(&OrderConfig{FieldName: "followers"}),
 	}
 }
 
@@ -137,7 +141,7 @@ func TestMarshalSchema(t *testing.T) {
 		require.True(t, schema.Fields[7].Default)
 		require.Equal(t, "github.com/google/uuid", schema.Fields[7].Info.PkgPath)
 
-		require.Len(t, schema.Edges, 2)
+		require.Len(t, schema.Edges, 3)
 		require.Equal(t, "groups", schema.Edges[0].Name)
 		require.Equal(t, "Group", schema.Edges[0].Type)
 		require.False(t, schema.Edges[0].Inverse)
@@ -152,6 +156,11 @@ func TestMarshalSchema(t *testing.T) {
 		require.Equal(t, "parent", schema.Edges[1].Ref.Name)
 		require.True(t, schema.Edges[1].Ref.Unique)
 		require.Equal(t, "user_parent_id", schema.Edges[1].Ref.StorageKey.Columns[0])
+
+		ant = schema.Edges[2].Annotations["order_config"].(map[string]interface{})
+		require.Equal(t, ant["FieldName"], "followers")
+		ant = schema.Edges[2].Ref.Annotations["order_config"].(map[string]interface{})
+		require.Equal(t, ant["FieldName"], "following")
 
 		require.Equal(t, []string{"name", "address"}, schema.Indexes[0].Fields)
 		require.True(t, schema.Indexes[0].Unique)


### PR DESCRIPTION
This PR contains one line fix (in `graph.go`), but additional tests to all annotations workflow. 