### PR TITLE
entc/gen: add SchemaType to generator

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -77,7 +77,7 @@ type (
 		// UserDefined indicates that this field was defined by the loaded schema.
 		// Unlike default id field, which is defined by the generator.
 		UserDefined bool
-		// SchemaType is a underlying type for a edge in the schema.
+		// SchemaType is a underlying column type for a field in the schema.
 		SchemaType map[string]string
 		// Annotations that were defined for the field in the schema.
 		// The mapping is from the Annotation.Name() to a JSON decoded object.

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -77,6 +77,8 @@ type (
 		// UserDefined indicates that this field was defined by the loaded schema.
 		// Unlike default id field, which is defined by the generator.
 		UserDefined bool
+		// SchemaType is a underlying type for a edge in the schema.
+		SchemaType map[string]string
 		// Annotations that were defined for the field in the schema.
 		// The mapping is from the Annotation.Name() to a JSON decoded object.
 		Annotations map[string]interface{}
@@ -189,6 +191,7 @@ func NewType(c *Config, schema *load.Schema) (*Type, error) {
 			UpdateDefault: f.UpdateDefault,
 			Immutable:     f.Immutable,
 			StructTag:     structTag(f.Name, f.Tag),
+			SchemaType:    f.SchemaType,
 			Validators:    f.Validators,
 			UserDefined:   true,
 			Annotations:   f.Annotations,


### PR DESCRIPTION
**What this PR does**: Exposes `field.SchemaType` to templates generated by `entc/gen`.