### PR TITLE
entc/gen: derive the id-type from the schema

### DIFF
--- a/entc/entc.go
+++ b/entc/entc.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/facebook/ent/entc/gen"
 	"github.com/facebook/ent/entc/load"
-	"github.com/facebook/ent/schema/field"
 )
 
 // LoadGraph loads the schema package from the given schema path,
@@ -57,9 +56,6 @@ func Generate(schemaPath string, cfg *gen.Config, options ...Option) (err error)
 		// default target-path for codegen is one dir above
 		// the schema.
 		cfg.Target = filepath.Dir(abs)
-	}
-	if cfg.IDType == nil {
-		cfg.IDType = &field.TypeInfo{Type: field.TypeInt}
 	}
 	for _, opt := range options {
 		if err := opt(cfg); err != nil {

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -98,7 +98,33 @@ func NewGraph(c *Config, schemas ...*load.Schema) (g *Graph, err error) {
 	for i := range schemas {
 		g.addIndexes(schemas[i])
 	}
+	g.defaults()
 	return
+}
+
+// defaultIDType holds the default value for IDType.
+var defaultIDType = &field.TypeInfo{Type: field.TypeInt}
+
+// defaults sets the default value of the IDType. The IDType field is used
+// by multiple templates. If the IDType wasn't provided, it will fallback to
+// int, or the one used in the schema (if all schemas share the same IDType).
+func (g *Graph) defaults() {
+	if g.IDType != nil {
+		return
+	}
+	if len(g.Nodes) == 0 {
+		g.IDType = defaultIDType
+		return
+	}
+	// Check that all nodes have the same type for the ID field.
+	for i := 0; i < len(g.Nodes)-1; i++ {
+		cid, nid := g.Nodes[i].ID.Type, g.Nodes[i+1].ID.Type
+		if cid.Type != nid.Type {
+			g.IDType = defaultIDType
+			return
+		}
+	}
+	g.IDType = g.Nodes[0].ID.Type
 }
 
 // Gen generates the artifacts for the graph.

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -160,11 +160,15 @@ type (
 
 // NewType creates a new type and its fields from the given schema.
 func NewType(c *Config, schema *load.Schema) (*Type, error) {
+	idType := c.IDType
+	if idType == nil {
+		idType = defaultIDType
+	}
 	typ := &Type{
 		Config: c,
 		ID: &Field{
 			Name:      "id",
-			Type:      c.IDType,
+			Type:      idType,
 			StructTag: structTag("id", ""),
 		},
 		schema:      schema,


### PR DESCRIPTION
derive the id-type from the schema if it was not provided