### PR TITLE
Fix naming conflict for 'Client'

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1254,6 +1254,7 @@ var (
 		"AggregateFunc",
 		"As",
 		"Asc",
+		"Client",
 		"Count",
 		"Debug",
 		"Desc",


### PR DESCRIPTION
Added `'Client'` in the `globalIdent` list. Fixes #873 