### PR TITLE
doc: replace CreateX reference to SaveX

### DIFF
--- a/doc/md/schema-edges.md
+++ b/doc/md/schema-edges.md
@@ -563,7 +563,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 	//        /   \
 	//       3     5
 	//
-	// Unlike `Create`, `CreateX` panics if an error occurs.
+	// Unlike `Save`, `SaveX` panics if an error occurs.
 	n1 := client.Node.
 		Create().
 		SetValue(1).

--- a/examples/README.md
+++ b/examples/README.md
@@ -615,7 +615,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 	//        /   \
 	//       3     5
 	//
-	// Unlike `Create`, `CreateX` panics if an error occurs.
+	// Unlike `Save`, `SaveX` panics if an error occurs.
 	n1 := client.Node.
 		Create().
 		SetValue(1).

--- a/examples/o2mrecur/example_test.go
+++ b/examples/o2mrecur/example_test.go
@@ -53,7 +53,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 	//       3     5
 	//
 
-	// Unlike `Create`, `CreateX` panics if an error occurs.
+	// Unlike `Save`, `SaveX` panics if an error occurs.
 	n1 := client.Node.
 		Create().
 		SetValue(1).


### PR DESCRIPTION
Looks like `CreateX` was deprecated and this comment is slightly outdated.