### PR TITLE
feat: Added Annotation Options

### DIFF
--- a/dialect/entsql/annotation.go
+++ b/dialect/entsql/annotation.go
@@ -34,6 +34,14 @@ type Annotation struct {
 	//	}
 	//
 	Collation string `json:"collation,omitempty"`
+
+	// Options defines the additional table options. For example:
+	//
+	//	entsql.Annotation{
+	//		Options: "ENGINE = INNODB",
+	//	}
+	//
+	Options string `json:"options,omitempty"`
 }
 
 // Name describes the annotation name.

--- a/dialect/sql/schema/mysql.go
+++ b/dialect/sql/schema/mysql.go
@@ -183,6 +183,9 @@ func (d *MySQL) tBuilder(t *Table) *sql.TableBuilder {
 		if collate := t.Annotation.Collation; collate != "" {
 			b.Collate(collate)
 		}
+		if opts := t.Annotation.Options; opts != "" {
+			b.Options(opts)
+		}
 	}
 	return b
 }

--- a/dialect/sql/schema/mysql_test.go
+++ b/dialect/sql/schema/mysql_test.go
@@ -63,13 +63,14 @@ func TestMySQL_Create(t *testing.T) {
 					Annotation: &entsql.Annotation{
 						Charset:   "utf8",
 						Collation: "utf8_general_ci",
+						Options:   "ENGINE = INNODB",
 					},
 				},
 			},
 			before: func(mock mysqlMock) {
 				mock.start("5.7.8")
 				mock.tableExists("users", false)
-				mock.ExpectExec(escape("CREATE TABLE IF NOT EXISTS `users`(`id` bigint AUTO_INCREMENT NOT NULL, `name` varchar(255) NULL, `age` bigint NOT NULL, `doc` json NULL, `enums` enum('a', 'b') NOT NULL, `uuid` char(36) binary NULL, `datetime` datetime NULL, `decimal` decimal(6,2) NOT NULL, PRIMARY KEY(`id`)) CHARACTER SET utf8 COLLATE utf8_general_ci")).
+				mock.ExpectExec(escape("CREATE TABLE IF NOT EXISTS `users`(`id` bigint AUTO_INCREMENT NOT NULL, `name` varchar(255) NULL, `age` bigint NOT NULL, `doc` json NULL, `enums` enum('a', 'b') NOT NULL, `uuid` char(36) binary NULL, `datetime` datetime NULL, `decimal` decimal(6,2) NOT NULL, PRIMARY KEY(`id`)) CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE = INNODB")).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectCommit()
 			},


### PR DESCRIPTION
resolves #924 

Added `Option` field in the `Annotations` struct so that users can specify additional options like `ENGINE = INNODB` when creating a table