### PR TITLE
fix invalid type, add an postgre type 'timestamp without time zone' to the scan colum

### DIFF
--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -241,7 +241,7 @@ func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 		c.Size = maxCharSize + 1
 	case "character", "character varying":
 		c.Type = field.TypeString
-	case "date", "time", "timestamp", "timestamp with time zone":
+	case "date", "time", "timestamp", "timestamp with time zone", "timestamp without time zone":
 		c.Type = field.TypeTime
 	case "bytea":
 		c.Type = field.TypeBytes


### PR DESCRIPTION
When the table already exists and has column the type is "timestamp without time zone", using migrate will return an error.

```
2020/11/14 05:09:34 failed printing schema changes: sql/schema: invalid type "timestamp without time zone" for column "create_time"
```
This is because when scanning column types, the corresponding ones are not processed.