### PR TITLE
dialect/sql/sqlgraph: fix postgres lastinsert scanning for non-integer types

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -1180,7 +1180,7 @@ func insertLastID(ctx context.Context, tx dialect.ExecQuerier, insert *sql.Inser
 }
 
 // insertLastIDs invokes the batch insert query on the transaction and returns the LastInsertID of all entities.
-func insertLastIDs(ctx context.Context, tx dialect.ExecQuerier, insert *sql.InsertBuilder) (ids []int64, err error) {
+func insertLastIDs(ctx context.Context, tx dialect.ExecQuerier, insert *sql.InsertBuilder) (ids []driver.Value, err error) {
 	query, args := insert.Query()
 	// PostgreSQL does not support the LastInsertId() method of sql.Result
 	// on Exec, and should be extracted manually using the `RETURNING` clause.
@@ -1205,7 +1205,7 @@ func insertLastIDs(ctx context.Context, tx dialect.ExecQuerier, insert *sql.Inse
 	if err != nil {
 		return nil, err
 	}
-	ids = make([]int64, 0, affected)
+	ids = make([]driver.Value, 0, affected)
 	switch insert.Dialect() {
 	case dialect.SQLite:
 		id -= affected - 1

--- a/entc/integration/customid/customid_test.go
+++ b/entc/integration/customid/customid_test.go
@@ -132,4 +132,19 @@ func CustomID(t *testing.T, client *ent.Client) {
 	require.Equal(t, "Chevrolet Camaro", bee.Model)
 	require.NotNil(t, bee.Edges.Owner)
 	require.Equal(t, pedro.ID, bee.Edges.Owner.ID)
+
+	pets = client.Pet.CreateBulk(
+		client.Pet.Create().SetID("luna").SetOwner(a8m),
+		client.Pet.Create().SetID("layla").SetOwner(a8m),
+	).SaveX(ctx)
+	require.Equal(t, "luna", pets[0].ID)
+	require.Equal(t, "layla", pets[1].ID)
+
+	u1, u2 := uuid.New(), uuid.New()
+	blobs := client.Blob.CreateBulk(
+		client.Blob.Create().SetID(u1),
+		client.Blob.Create().SetID(u2),
+	).SaveX(ctx)
+	require.Equal(t, u1, blobs[0].ID)
+	require.Equal(t, u2, blobs[1].ID)
 }


### PR DESCRIPTION
Fixed #985