### PR TITLE
fix: linting errors for comments

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -2020,6 +2020,7 @@ func (b *Builder) Err() error {
 // An Op represents a predicate operator.
 type Op int
 
+// Predicate operators
 const (
 	OpEQ      Op = iota // logical and.
 	OpNEQ               // <>

--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1165,10 +1165,12 @@ func (p *Predicate) ContainsFold(col, sub string) *Predicate {
 	})
 }
 
+// CompositeGT returns a comiposite ">" predicate
 func CompositeGT(columns []string, args ...interface{}) *Predicate {
 	return P().CompositeGT(columns, args...)
 }
 
+// CompositeLT returns a comiposite "<" predicate
 func CompositeLT(columns []string, args ...interface{}) *Predicate {
 	return P().CompositeLT(columns, args...)
 }
@@ -1185,13 +1187,13 @@ func (p *Predicate) compositeP(operator string, columns []string, args ...interf
 	})
 }
 
-// GT returns a composite ">" predicate.
+// CompositeGT returns a composite ">" predicate.
 func (p *Predicate) CompositeGT(columns []string, args ...interface{}) *Predicate {
 	const operator = " > "
 	return p.compositeP(operator, columns, args...)
 }
 
-// LT appends a composite "<" predicate.
+// CompositeLT appends a composite "<" predicate.
 func (p *Predicate) CompositeLT(columns []string, args ...interface{}) *Predicate {
 	const operator = " < "
 	return p.compositeP(operator, columns, args...)

--- a/dialect/sql/sqlgraph/entql.go
+++ b/dialect/sql/sqlgraph/entql.go
@@ -41,7 +41,7 @@ type (
 	}
 )
 
-// AddEdge adds an edge to the graph. It fails, if one of the node
+// AddE adds an edge to the graph. It fails, if one of the node
 // types is missing.
 //
 //	g.AddE("pets", spec, "user", "pet")

--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -2,7 +2,7 @@
 // This source code is licensed under the Apache 2.0 license found
 // in the LICENSE file in the root directory of this source tree.
 
-// sqlgraph provides graph abstraction capabilities on top
+// Package sqlgraph provides graph abstraction capabilities on top
 // of sql-based databases for ent codegen.
 package sqlgraph
 

--- a/entc/gen/feature.go
+++ b/entc/gen/feature.go
@@ -57,20 +57,20 @@ type FeatureStage int
 const (
 	_ FeatureStage = iota
 
-	// An Experimental feature is one that is in development,
-	// and it's actively tested in the integration environment.
+	// Experimental features are in development, and actively being tested in the
+	// integration environment.
 	Experimental
 
-	// An Alpha feature is one that its initial development was
-	// finished, it's tested on the infra of the ent team, but
-	// we expect breaking-changes to its API.
+	// Alpha features are features whose initial development was finished, tested
+	// on the infra of the ent team, but we expect breaking-changes to their APIs.
 	Alpha
 
-	// A Beta feature is an Alpha feature that was added to the entgo.io
-	// documentation, and no breaking-changes are expected for it.
+	// Beta features are Alpha features that were added to the entgo.io
+	// documentation, and no breaking-changes are expected for them.
 	Beta
 
-	// A Stable feature is a Beta feature that was running a while on ent infra.
+	// Stable features are Beta features that were running for a while on ent
+	// infra.
 	Stable
 )
 

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -494,7 +494,7 @@ type Snapshot struct {
 	Features []string
 }
 
-// MarshalSchema returns a JSON string represents the graph schema in loadable format.
+// SchemaSnapshot returns a JSON string represents the graph schema in loadable format.
 func (g *Graph) SchemaSnapshot() (string, error) {
 	schemas := make([]*load.Schema, len(g.Nodes))
 	for i := range g.Nodes {

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -579,7 +579,7 @@ func (t Type) CreateName() string {
 	return pascal(t.Name) + "Create"
 }
 
-// CreateBulk returns the struct name denoting the create-bulk-builder for this type.
+// CreateBulkName returns the struct name denoting the create-bulk-builder for this type.
 func (t Type) CreateBulkName() string {
 	return pascal(t.Name) + "CreateBulk"
 }
@@ -641,7 +641,7 @@ func (t Type) HookPositions() []*load.Position {
 	return nil
 }
 
-// NumHooks returns the number of privacy-policy declared in the type schema.
+// NumPolicy returns the number of privacy-policy declared in the type schema.
 func (t Type) NumPolicy() int {
 	if t.schema != nil {
 		return len(t.schema.Policy)
@@ -736,7 +736,7 @@ func (f Field) StructField() string {
 	return pascal(f.Name)
 }
 
-// Enums returns the enum values of a field.
+// EnumNames returns the enum values of a field.
 func (f Field) EnumNames() []string {
 	names := make([]string, 0, len(f.def.Enums))
 	for _, e := range f.Enums {
@@ -1081,7 +1081,7 @@ func (e Edge) O2O() bool { return e.Rel.Type == O2O }
 // IsInverse returns if this edge is an inverse edge.
 func (e Edge) IsInverse() bool { return e.Inverse != "" }
 
-// Constant returns the constant name of the edge for the gremlin dialect.
+// LabelConstant returns the constant name of the edge for the gremlin dialect.
 // If the edge is inverse, it returns the constant name of the owner-edge (assoc-edge).
 func (e Edge) LabelConstant() string {
 	name := e.Name
@@ -1091,7 +1091,7 @@ func (e Edge) LabelConstant() string {
 	return pascal(name) + "Label"
 }
 
-// InverseConstant returns the inverse constant name of the edge.
+// InverseLabelConstant returns the inverse constant name of the edge.
 func (e Edge) InverseLabelConstant() string { return pascal(e.Name) + "InverseLabel" }
 
 // TableConstant returns the constant name of the relation table.

--- a/schema/edge/edge.go
+++ b/schema/edge/edge.go
@@ -174,22 +174,22 @@ type StorageKey struct {
 // StorageOption allows for setting the storage configuration using functional options.
 type StorageOption func(*StorageKey)
 
-// The Table option sets the table name of M2M edges.
+// Table sets the table name option for M2M edges.
 func Table(name string) StorageOption {
 	return func(key *StorageKey) {
 		key.Table = name
 	}
 }
 
-// The Column option sets the foreign-key column name for O2O, O2M and M2O
-// edges. Note that, for M2M edges (2 columns), use the edge.Columns option.
+// Column sets the foreign-key column name option for O2O, O2M and M2O edges.
+// Note that, for M2M edges (2 columns), use the edge.Columns option.
 func Column(name string) StorageOption {
 	return func(key *StorageKey) {
 		key.Columns = []string{name}
 	}
 }
 
-// The Columns option sets the foreign-key column names for M2M edges.
+// Columns sets the foreign-key column names option for M2M edges.
 // The 1st column defines the name of the "To" edge, and the 2nd defines
 // the name of the "From" edge (inverse edge).
 // Note that, for O2O, O2M and M2O edges, use the edge.Column option.

--- a/schema/index/index.go
+++ b/schema/index/index.go
@@ -68,7 +68,7 @@ func (b *Builder) Fields(fields ...string) *Builder {
 	return b
 }
 
-// FromEdges sets the fields index to be unique under the set of edges (sub-graph). For example:
+// Edges sets the fields index to be unique under the set of edges (sub-graph). For example:
 //
 //	func (T) Indexes() []ent.Index {
 //


### PR DESCRIPTION
I was noticing a few linting errors relating to comments. Personally, I like a warning-free environment so that important warnings don't get lost. There are quite a few more linting problems but I left them alone as they would require changes to function signatures or they are false-negatives and that's outside the scope of this PR.

I also didn't touch any of the integration comments as I'm not sure what's connected to docs and what isn't. 

Happy to review if needed.

<details>
<summary>What's left</summary>

```
dialect\sql\builder.go:2024:2: exported const OpEQ should have comment (or a comment on this block) or be unexported
entc\gen\internal\bindata.go:613:5: var _templateDialectSqlByTmpl should be _templateDialectSQLByTmpl
entc\gen\internal\bindata.go:615:6: func templateDialectSqlByTmplBytes should be templateDialectSQLByTmplBytes
entc\gen\internal\bindata.go:622:6: func templateDialectSqlByTmpl should be templateDialectSQLByTmpl
entc\gen\internal\bindata.go:633:5: var _templateDialectSqlCreateTmpl should be _templateDialectSQLCreateTmpl
entc\gen\internal\bindata.go:635:6: func templateDialectSqlCreateTmplBytes should be templateDialectSQLCreateTmplBytes
entc\gen\internal\bindata.go:642:6: func templateDialectSqlCreateTmpl should be templateDialectSQLCreateTmpl
entc\gen\internal\bindata.go:653:5: var _templateDialectSqlDecodeTmpl should be _templateDialectSQLDecodeTmpl
entc\gen\internal\bindata.go:655:6: func templateDialectSqlDecodeTmplBytes should be templateDialectSQLDecodeTmplBytes
entc\gen\internal\bindata.go:662:6: func templateDialectSqlDecodeTmpl should be templateDialectSQLDecodeTmpl
entc\gen\internal\bindata.go:673:5: var _templateDialectSqlDeleteTmpl should be _templateDialectSQLDeleteTmpl
entc\gen\internal\bindata.go:675:6: func templateDialectSqlDeleteTmplBytes should be templateDialectSQLDeleteTmplBytes
entc\gen\internal\bindata.go:682:6: func templateDialectSqlDeleteTmpl should be templateDialectSQLDeleteTmpl
entc\gen\internal\bindata.go:693:5: var _templateDialectSqlEntqlTmpl should be _templateDialectSQLEntqlTmpl
entc\gen\internal\bindata.go:695:6: func templateDialectSqlEntqlTmplBytes should be templateDialectSQLEntqlTmplBytes
entc\gen\internal\bindata.go:702:6: func templateDialectSqlEntqlTmpl should be templateDialectSQLEntqlTmpl
entc\gen\internal\bindata.go:713:5: var _templateDialectSqlErrorsTmpl should be _templateDialectSQLErrorsTmpl
entc\gen\internal\bindata.go:715:6: func templateDialectSqlErrorsTmplBytes should be templateDialectSQLErrorsTmplBytes
entc\gen\internal\bindata.go:722:6: func templateDialectSqlErrorsTmpl should be templateDialectSQLErrorsTmpl
entc\gen\internal\bindata.go:733:5: var _templateDialectSqlGlobalsTmpl should be _templateDialectSQLGlobalsTmpl
entc\gen\internal\bindata.go:735:6: func templateDialectSqlGlobalsTmplBytes should be templateDialectSQLGlobalsTmplBytes
entc\gen\internal\bindata.go:742:6: func templateDialectSqlGlobalsTmpl should be templateDialectSQLGlobalsTmpl
entc\gen\internal\bindata.go:753:5: var _templateDialectSqlGroupTmpl should be _templateDialectSQLGroupTmpl
entc\gen\internal\bindata.go:755:6: func templateDialectSqlGroupTmplBytes should be templateDialectSQLGroupTmplBytes
entc\gen\internal\bindata.go:762:6: func templateDialectSqlGroupTmpl should be templateDialectSQLGroupTmpl
entc\gen\internal\bindata.go:773:5: var _templateDialectSqlMetaTmpl should be _templateDialectSQLMetaTmpl
entc\gen\internal\bindata.go:775:6: func templateDialectSqlMetaTmplBytes should be templateDialectSQLMetaTmplBytes
entc\gen\internal\bindata.go:782:6: func templateDialectSqlMetaTmpl should be templateDialectSQLMetaTmpl
entc\gen\internal\bindata.go:793:5: var _templateDialectSqlOpenTmpl should be _templateDialectSQLOpenTmpl
entc\gen\internal\bindata.go:795:6: func templateDialectSqlOpenTmplBytes should be templateDialectSQLOpenTmplBytes
entc\gen\internal\bindata.go:802:6: func templateDialectSqlOpenTmpl should be templateDialectSQLOpenTmpl
entc\gen\internal\bindata.go:813:5: var _templateDialectSqlPredicateTmpl should be _templateDialectSQLPredicateTmpl
entc\gen\internal\bindata.go:815:6: func templateDialectSqlPredicateTmplBytes should be templateDialectSQLPredicateTmplBytes
entc\gen\internal\bindata.go:822:6: func templateDialectSqlPredicateTmpl should be templateDialectSQLPredicateTmpl
entc\gen\internal\bindata.go:833:5: var _templateDialectSqlQueryTmpl should be _templateDialectSQLQueryTmpl
entc\gen\internal\bindata.go:835:6: func templateDialectSqlQueryTmplBytes should be templateDialectSQLQueryTmplBytes
entc\gen\internal\bindata.go:842:6: func templateDialectSqlQueryTmpl should be templateDialectSQLQueryTmpl
entc\gen\internal\bindata.go:853:5: var _templateDialectSqlSelectTmpl should be _templateDialectSQLSelectTmpl
entc\gen\internal\bindata.go:855:6: func templateDialectSqlSelectTmplBytes should be templateDialectSQLSelectTmplBytes
entc\gen\internal\bindata.go:862:6: func templateDialectSqlSelectTmpl should be templateDialectSQLSelectTmpl
entc\gen\internal\bindata.go:873:5: var _templateDialectSqlTxTmpl should be _templateDialectSQLTxTmpl
entc\gen\internal\bindata.go:875:6: func templateDialectSqlTxTmplBytes should be templateDialectSQLTxTmplBytes
entc\gen\internal\bindata.go:882:6: func templateDialectSqlTxTmpl should be templateDialectSQLTxTmpl
entc\gen\internal\bindata.go:893:5: var _templateDialectSqlUpdateTmpl should be _templateDialectSQLUpdateTmpl
entc\gen\internal\bindata.go:895:6: func templateDialectSqlUpdateTmplBytes should be templateDialectSQLUpdateTmplBytes
entc\gen\internal\bindata.go:902:6: func templateDialectSqlUpdateTmpl should be templateDialectSQLUpdateTmpl
entc\integration\config\ent\schema\user.go:15:6: exported type Mixin should have comment or be unexported
entc\integration\customid\ent\schema\car.go:14:6: exported type IDMixin should have comment or be unexported
entc\integration\customid\ent\schema\car.go:18:1: exported method IDMixin.Fields should have comment or be unexported
entc\integration\ent\role\role.go:7:6: exported type Role should have comment or be unexported
entc\integration\ent\role\role.go:10:2: exported const Admin should have comment (or a comment on this block) or be unexported
entc\integration\ent\role\role.go:17:1: exported method Role.Values should have comment or be unexported
entc\integration\ent\schema\card.go:21:1: exported method Card.Annotations should have comment or be unexported
entc\integration\ent\schema\card.go:35:1: exported method Card.Mixin should have comment or be unexported
entc\integration\ent\schema\fieldtype.go:147:2: exported type Int should have comment or be unexported
entc\integration\ent\schema\fieldtype.go:148:2: exported type Int8 should have comment or be unexported
entc\integration\ent\schema\fieldtype.go:149:2: exported type Int64 should have comment or be unexported
entc\integration\ent\schema\fieldtype.go:150:2: exported type Status should have comment or be unexported
entc\integration\ent\schema\fieldtype.go:151:2: exported type Float64 should have comment or be unexported
entc\integration\ent\schema\fieldtype.go:152:2: exported type Float32 should have comment or be unexported
entc\integration\ent\schema\fieldtype.go:155:6: exported type Link should have comment or be unexported
entc\integration\ent\schema\fieldtype.go:181:6: exported type MAC should have comment or be unexported
entc\integration\ent\schema\pet.go:38:1: exported method Pet.Indexes should have comment or be unexported
entc\integration\ent\schema\spec.go:12:6: exported type Spec should have comment or be unexported
entc\integration\ent\schema\task.go:31:6: exported type Priority should have comment or be unexported
entc\integration\ent\schema\task.go:34:2: exported const PriorityLow should have comment (or a comment on this block) or be unexported
entc\integration\ent\schema\task.go:52:1: exported method Priority.Validate should have comment or be unexported
entc\integration\ent\schema\user.go:19:1: exported method User.Mixin should have comment or be unexported
entc\integration\ent\template\ext.go:12:1: exported method Extension.Name should have comment or be unexported
entc\integration\hooks\ent\schema\card.go:21:1: comment on exported type RejectUpdate should be of the form "RejectUpdate ..." (with optional leading article)
entc\integration\hooks\ent\schema\card.go:27:1: exported method RejectUpdate.Hooks should have comment or be unexported
entc\integration\hooks\ent\schema\card.go:38:1: exported method Card.Mixin should have comment or be unexported
entc\integration\hooks\ent\schema\card.go:44:1: exported method Card.Hooks should have comment or be unexported
entc\integration\hooks\ent\schema\card.go:74:1: exported method Card.Fields should have comment or be unexported
entc\integration\hooks\ent\schema\card.go:90:1: exported method Card.Edges should have comment or be unexported
entc\integration\hooks\ent\schema\user.go:50:6: exported type VersionMixin should have comment or be unexported
entc\integration\hooks\ent\schema\user.go:54:1: exported method VersionMixin.Fields should have comment or be unexported
entc\integration\hooks\ent\schema\user.go:61:1: exported method VersionMixin.Hooks should have comment or be unexported
entc\integration\hooks\ent\schema\user.go:67:1: exported function VersionHook should have comment or be unexported
entc\integration\json\ent\schema\user.go:41:6: exported type T should have comment or be unexported
entc\integration\migrate\entv1\schema\user.go:47:1: exported method User.Edges should have comment or be unexported
entc\integration\migrate\entv1\schema\user.go:59:1: exported method User.Indexes should have comment or be unexported
entc\integration\migrate\entv1\schema\user.go:66:6: exported type Car should have comment or be unexported
entc\integration\migrate\entv1\schema\user.go:70:1: exported method Car.Edges should have comment or be unexported
entc\integration\migrate\entv2\schema\user.go:15:6: exported type Mixin should have comment or be unexported
entc\integration\migrate\entv2\schema\user.go:19:1: exported method Mixin.Fields should have comment or be unexported
entc\integration\migrate\entv2\schema\user.go:34:1: exported method User.Mixin should have comment or be unexported
entc\integration\migrate\entv2\schema\user.go:86:1: exported method User.Edges should have comment or be unexported
entc\integration\migrate\entv2\schema\user.go:100:1: exported method User.Indexes should have comment or be unexported
entc\integration\migrate\entv2\schema\user.go:109:6: exported type Car should have comment or be unexported
entc\integration\migrate\entv2\schema\user.go:113:1: exported method Car.Edges should have comment or be unexported
entc\integration\migrate\entv2\schema\user.go:130:1: exported method Pet.Edges should have comment or be unexported
entc\integration\privacy\ent\schema\base.go:19:1: comment on exported method BaseMixin.Policy should be of the form "Policy ..."
entc\integration\privacy\rule\rule.go:187:1: comment on exported function LogTaskMutationHook should be of the form "LogTaskMutationHook ..."
entc\integration\privacy\viewer\viewer.go:38:1: exported method UserViewer.Teams should have comment or be unexported
entc\integration\privacy\viewer\viewer.go:42:1: exported method UserViewer.Can should have comment or be unexported
entc\integration\privacy\viewer\viewer.go:49:1: exported method UserViewer.Admin should have comment or be unexported
entc\integration\privacy\viewer\viewer.go:58:1: exported method AppViewer.Teams should have comment or be unexported
entc\integration\privacy\viewer\viewer.go:62:1: exported method AppViewer.Can should have comment or be unexported
entc\integration\privacy\viewer\viewer.go:69:1: exported method AppViewer.Admin should have comment or be unexported
examples\privacyadmin\viewer\viewer.go:31:1: exported method UserViewer.Admin should have comment or be unexported
examples\privacytenant\ent\schema\group.go:15:1: comment on exported type Group should be of the form "Group ..." (with optional leading article)
examples\privacytenant\viewer\viewer.go:35:1: exported method UserViewer.Admin should have comment or be unexported
examples\privacytenant\viewer\viewer.go:39:1: exported method UserViewer.Tenant should have comment or be unexported
examples\start\start.go:62:1: exported function CreateUser should have comment or be unexported
examples\start\start.go:75:1: exported function QueryUser should have comment or be unexported
examples\start\start.go:89:1: exported function CreateCars should have comment or be unexported
examples\start\start.go:125:1: exported function QueryCars should have comment or be unexported
examples\start\start.go:143:1: exported function QueryCarUsers should have comment or be unexported
examples\start\start.go:160:1: exported function CreateGraph should have comment or be unexported
examples\start\start.go:227:1: exported function QueryGithub should have comment or be unexported
examples\start\start.go:242:1: exported function QueryArielCars should have comment or be unexported
examples\start\start.go:268:1: exported function QueryGroupWithUsers should have comment or be unexported
privacy\privacy.go:20:2: error var Allow should have name of the form ErrFoo
privacy\privacy.go:24:2: error var Deny should have name of the form ErrFoo
privacy\privacy.go:28:2: error var Skip should have name of the form ErrFoo
privacy\privacy.go:134:1: error should be the last type when returning multiple items
schema\edge\edge.go:28:37: exported func To returns unexported type *edge.assocBuilder, which can be annoying to use
schema\edge\edge.go:33:39: exported func From returns unexported type *edge.inverseBuilder, which can be annoying to use
schema\field\field.go:22:26: exported func String returns unexported type *field.stringBuilder, which can be annoying to use
schema\field\field.go:31:24: exported func Text returns unexported type *field.stringBuilder, which can be annoying to use
schema\field\field.go:41:25: exported func Bytes returns unexported type *field.bytesBuilder, which can be annoying to use
schema\field\field.go:49:24: exported func Bool returns unexported type *field.boolBuilder, which can be annoying to use
schema\field\field.go:57:24: exported func Time returns unexported type *field.timeBuilder, which can be annoying to use
schema\field\field.go:74:41: exported func JSON returns unexported type *field.jsonBuilder, which can be annoying to use
schema\field\field.go:93:27: exported func Strings returns unexported type *field.jsonBuilder, which can be annoying to use
schema\field\field.go:98:24: exported func Ints returns unexported type *field.jsonBuilder, which can be annoying to use
schema\field\field.go:103:26: exported func Floats returns unexported type *field.jsonBuilder, which can be annoying to use
schema\field\field.go:116:24: exported func Enum returns unexported type *field.enumBuilder, which can be annoying to use
schema\field\field.go:127:43: exported func UUID returns unexported type *field.uuidBuilder, which can be annoying to use
schema\field\numeric.go:17:23: exported func Int returns unexported type *field.intBuilder, which can be annoying to use
schema\field\numeric.go:25:24: exported func Uint returns unexported type *field.uintBuilder, which can be annoying to use
schema\field\numeric.go:33:24: exported func Int8 returns unexported type *field.int8Builder, which can be annoying to use
schema\field\numeric.go:41:25: exported func Int16 returns unexported type *field.int16Builder, which can be annoying to use
schema\field\numeric.go:49:25: exported func Int32 returns unexported type *field.int32Builder, which can be annoying to use
schema\field\numeric.go:57:25: exported func Int64 returns unexported type *field.int64Builder, which can be annoying to use
schema\field\numeric.go:65:25: exported func Uint8 returns unexported type *field.uint8Builder, which can be annoying to use
schema\field\numeric.go:73:26: exported func Uint16 returns unexported type *field.uint16Builder, which can be annoying to use
schema\field\numeric.go:81:26: exported func Uint32 returns unexported type *field.uint32Builder, which can be annoying to use
schema\field\numeric.go:89:26: exported func Uint64 returns unexported type *field.uint64Builder, which can be annoying to use
schema\field\numeric.go:97:25: exported func Float returns unexported type *field.float64Builder, which can be annoying to use
schema\field\numeric.go:105:27: exported func Float32 returns unexported type *field.float32Builder, which can be annoying to use
```
</details>