### PR TITLE
Repro/bug

### DIFF
--- a/entc/integration/integration_test.go
+++ b/entc/integration/integration_test.go
@@ -135,6 +135,7 @@ var (
 		EagerLoading,
 		Mutation,
 		CreateBulk,
+		Issue1,
 	}
 )
 

--- a/entc/integration/issue_test.go
+++ b/entc/integration/issue_test.go
@@ -1,0 +1,22 @@
+// Copyright 2019-present Facebook Inc. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
+package integration
+
+import (
+	"context"
+	"github.com/facebook/ent/entc/integration/ent"
+	"github.com/facebook/ent/entc/integration/ent/node"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Issue1(t *testing.T, client *ent.Client) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	nd := client.Node.Create().SetValue(1e3).SaveX(ctx)
+	err := client.Node.Update().Where(node.ID(nd.ID)).Exec(ctx)
+	require.NoError(err)
+}


### PR DESCRIPTION
Came across this while trying to setup https://github.com/volatiletech/boilbench for ent

```
err := client.Node.Update().Where(node.ID(nd.ID)).Exec(ctx)
```

The code does not actually make sense but it exposes a weird bug.
I think it only happens on models with foreign keys