### PR TITLE
entc/init: name conflict checks

### DIFF
--- a/cmd/internal/base/base.go
+++ b/cmd/internal/base/base.go
@@ -182,7 +182,7 @@ func initEnv(target string, names []string) error {
 		return fmt.Errorf("create dir %s: %w", target, err)
 	}
 	for _, name := range names {
-		if err := gen.CheckNameConflicts(name); err != nil {
+		if err := gen.ValidSchemaName(name); err != nil {
 			return fmt.Errorf("init schema %s: %w", name, err)
 		}
 		b := bytes.NewBuffer(nil)

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -683,14 +683,14 @@ func (t Type) RelatedTypes() []*Type {
 // ValidSchemaName will determine if a name is going to conflict with any
 // pre-defined names
 func ValidSchemaName(name string) error {
-	// Golang keywords and identifiers are lower case
-	lowerName := strings.ToLower(name)
+	// schema package is lower-cased (see Type.Package)
+	pkg := strings.ToLower(name)
 
-	if token.Lookup(lowerName).IsKeyword() {
-		return fmt.Errorf("schema lowercase name conflicts with Go keyword %q", lowerName)
+	if token.Lookup(pkg).IsKeyword() {
+		return fmt.Errorf("schema lowercase name conflicts with Go keyword %q", pkg)
 	}
-	if types.Universe.Lookup(lowerName) != nil {
-		return fmt.Errorf("schema lowercase name conflicts with Go predeclared identifier %q", lowerName)
+	if types.Universe.Lookup(pkg) != nil {
+		return fmt.Errorf("schema lowercase name conflicts with Go predeclared identifier %q", pkg)
 	}
 	if _, ok := globalIdent[name]; ok {
 		return fmt.Errorf("schema name conflicts with ent predeclared identifier %q", name)

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -680,13 +680,17 @@ func (t Type) RelatedTypes() []*Type {
 	return related
 }
 
-// CheckNameConflicts will determine if a name is going to conflict with a pre-defined name
+// CheckNameConflicts will determine if a name is going to conflict with any
+// pre-defined names
 func CheckNameConflicts(name string) error {
-	if token.Lookup(name).IsKeyword() {
-		return fmt.Errorf("schema lowercase name conflicts with Go keyword %q", name)
+	// Golang keywords and identifiers are lower case
+	lowerName := strings.ToLower(name)
+
+	if token.Lookup(lowerName).IsKeyword() {
+		return fmt.Errorf("schema lowercase name conflicts with Go keyword %q", lowerName)
 	}
-	if types.Universe.Lookup(name) != nil {
-		return fmt.Errorf("schema lowercase name conflicts with Go predeclared identifier %q", name)
+	if types.Universe.Lookup(lowerName) != nil {
+		return fmt.Errorf("schema lowercase name conflicts with Go predeclared identifier %q", lowerName)
 	}
 	if _, ok := globalIdent[name]; ok {
 		return fmt.Errorf("schema name conflicts with ent predeclared identifier %q", name)
@@ -696,7 +700,7 @@ func CheckNameConflicts(name string) error {
 
 // check checks the schema type.
 func (t *Type) check() error {
-	return CheckNameConflicts(t.Package())
+	return CheckNameConflicts(t.Name)
 }
 
 // checkField checks the schema field.

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -680,19 +680,23 @@ func (t Type) RelatedTypes() []*Type {
 	return related
 }
 
-// check checks the schema type.
-func (t *Type) check() error {
-	pkg := t.Package()
-	if token.Lookup(pkg).IsKeyword() {
-		return fmt.Errorf("schema lowercase name conflicts with Go keyword %q", pkg)
+// CheckNameConflicts will determine if a name is going to conflict with a pre-defined name
+func CheckNameConflicts(name string) error {
+	if token.Lookup(name).IsKeyword() {
+		return fmt.Errorf("schema lowercase name conflicts with Go keyword %q", name)
 	}
-	if types.Universe.Lookup(pkg) != nil {
-		return fmt.Errorf("schema lowercase name conflicts with Go predeclared identifier %q", pkg)
+	if types.Universe.Lookup(name) != nil {
+		return fmt.Errorf("schema lowercase name conflicts with Go predeclared identifier %q", name)
 	}
-	if _, ok := globalIdent[t.Name]; ok {
-		return fmt.Errorf("schema name conflicts with ent predeclared identifier %q", t.Name)
+	if _, ok := globalIdent[name]; ok {
+		return fmt.Errorf("schema name conflicts with ent predeclared identifier %q", name)
 	}
 	return nil
+}
+
+// check checks the schema type.
+func (t *Type) check() error {
+	return CheckNameConflicts(t.Package())
 }
 
 // checkField checks the schema field.

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -186,7 +186,7 @@ func NewType(c *Config, schema *load.Schema) (*Type, error) {
 		fields:      make(map[string]*Field, len(schema.Fields)),
 		foreignKeys: make(map[string]struct{}),
 	}
-	if err := typ.check(); err != nil {
+	if err := ValidSchemaName(typ.Name); err != nil {
 		return nil, err
 	}
 	for _, f := range schema.Fields {
@@ -680,9 +680,9 @@ func (t Type) RelatedTypes() []*Type {
 	return related
 }
 
-// CheckNameConflicts will determine if a name is going to conflict with any
+// ValidSchemaName will determine if a name is going to conflict with any
 // pre-defined names
-func CheckNameConflicts(name string) error {
+func ValidSchemaName(name string) error {
 	// Golang keywords and identifiers are lower case
 	lowerName := strings.ToLower(name)
 
@@ -696,11 +696,6 @@ func CheckNameConflicts(name string) error {
 		return fmt.Errorf("schema name conflicts with ent predeclared identifier %q", name)
 	}
 	return nil
-}
-
-// check checks the schema type.
-func (t *Type) check() error {
-	return CheckNameConflicts(t.Name)
 }
 
 // checkField checks the schema field.


### PR DESCRIPTION
Adds in name conflict checking when running `ent init` to provide better feedback to the user when generating new schemas.
Also made error handling more concise for `init` to show what went wrong when

Closes #1109 

New Error: `ent/init: init schema Client: schema name conflicts with ent predeclared identifier "Client"`