### PR TITLE
ent: fix Policy documentation code formatting

### DIFF
--- a/ent.go
+++ b/ent.go
@@ -180,14 +180,13 @@ type (
 	// The Policy type defines the write privacy policy of an entity.
 	// The usage for the interface is as follows:
 	//
-	// type T struct {
-	//   ent.Schema
-	// }
+	//	type T struct {
+	//		ent.Schema
+	//	}
 	//
-	// func(T) Policy() ent.Policy {
-	//     return privacy.AlwaysAllowReadWrite()
-	// }
-	//
+	//	func(T) Policy() ent.Policy {
+	//		return privacy.AlwaysAllowReadWrite()
+	//	}
 	//
 	Policy interface {
 		EvalMutation(context.Context, Mutation) error


### PR DESCRIPTION
Fixes the indentation of the usage code example under the `Policy` type
so that proper formatting is applied.

Previously had formatting like:

>type T struct {
>```
>ent.Schema
>```
>}

Updates to:

>```
>type T struct {
>    ent.Schema
>}
>```