### PR TITLE
schema/field: relax signature of DefaultFunc for String() and Bytes()

### DIFF
--- a/schema/field/field.go
+++ b/schema/field/field.go
@@ -600,7 +600,8 @@ func (b *bytesBuilder) Descriptor() *Descriptor {
 	// If the Default is present and a function, check that it's signtaure is appropriate.
 	if b.desc.Default != nil {
 		typ := reflect.TypeOf(b.desc.Default)
-		if typ.Kind() == reflect.Func && (typ.NumIn() != 0 || typ.NumOut() != 1 || typ.Out(0).String() != b.desc.Info.String()) {
+		// We check against "[]uint8" here because the reflect package treats byte as an alias to uint8.
+		if typ.Kind() == reflect.Func && (typ.NumIn() != 0 || typ.NumOut() != 1 || typ.Out(0).String() != "[]uint8") {
 			b.desc.Err = fmt.Errorf("expect type (func() %s) for default value", b.desc.Info)
 		}
 	}

--- a/schema/field/field.go
+++ b/schema/field/field.go
@@ -213,7 +213,7 @@ func (b *stringBuilder) Default(s string) *stringBuilder {
 //	field.String("cuid").
 //		DefaultFunc(cuid.New)
 //
-func (b *stringBuilder) DefaultFunc(fn func() string) *stringBuilder {
+func (b *stringBuilder) DefaultFunc(fn interface{}) *stringBuilder {
 	b.desc.Default = fn
 	return b
 }
@@ -295,6 +295,13 @@ func (b *stringBuilder) Annotations(annotations ...schema.Annotation) *stringBui
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
 func (b *stringBuilder) Descriptor() *Descriptor {
+	// If the Default is present and a function, check that it's signtaure is appropriate.
+	if b.desc.Default != nil {
+		typ := reflect.TypeOf(b.desc.Default)
+		if typ.Kind() == reflect.Func && (typ.NumIn() != 0 || typ.NumOut() != 1 || typ.Out(0).String() != b.desc.Info.String()) {
+			b.desc.Err = fmt.Errorf("expect type (func() %s) for default value", b.desc.Info)
+		}
+	}
 	return b.desc
 }
 

--- a/schema/field/field.go
+++ b/schema/field/field.go
@@ -507,7 +507,7 @@ func (b *bytesBuilder) Default(v []byte) *bytesBuilder {
 //	field.Bytes("cuid").
 //		DefaultFunc(cuid.New)
 //
-func (b *bytesBuilder) DefaultFunc(fn func() []byte) *bytesBuilder {
+func (b *bytesBuilder) DefaultFunc(fn interface{}) *bytesBuilder {
 	b.desc.Default = fn
 	return b
 }
@@ -597,6 +597,13 @@ func (b *bytesBuilder) SchemaType(types map[string]string) *bytesBuilder {
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
 func (b *bytesBuilder) Descriptor() *Descriptor {
+	// If the Default is present and a function, check that it's signtaure is appropriate.
+	if b.desc.Default != nil {
+		typ := reflect.TypeOf(b.desc.Default)
+		if typ.Kind() == reflect.Func && (typ.NumIn() != 0 || typ.NumOut() != 1 || typ.Out(0).String() != b.desc.Info.String()) {
+			b.desc.Err = fmt.Errorf("expect type (func() %s) for default value", b.desc.Info)
+		}
+	}
 	return b.desc
 }
 


### PR DESCRIPTION
Using `GoType()` will generate code that expects the provided type throughout generated code -- it's not appropriate to restrict the signature of DefaultFunc in these cases.

This change relaxes the signature of DefaultFunc for `stringBuilder` and `bytesBuilder` and does a reflect-based check inside of `Descriptor()`.