### PR TITLE
Fix ptr annotation

### DIFF
--- a/entc/gen/func.go
+++ b/entc/gen/func.go
@@ -418,7 +418,12 @@ func dumpFields(v interface{}) string {
 		}
 		fv := rv.Field(i)
 		if !fv.IsZero() {
-			fields = append(fields, fmt.Sprintf("%s: %#v", f.Name, fv.Interface()))
+			if fv.Kind() == reflect.Ptr {
+				fv = reflect.Indirect(fv)
+				fields = append(fields, fmt.Sprintf("%s: &[]%s{%#v}[0]", f.Name, fv.Type(), fv.Interface()))
+			} else {
+				fields = append(fields, fmt.Sprintf("%s: %#v", f.Name, fv.Interface()))
+			}
 		}
 	}
 	return strings.Join(fields, ", ")

--- a/entc/gen/type_test.go
+++ b/entc/gen/type_test.go
@@ -273,6 +273,23 @@ func TestField_DefaultName(t *testing.T) {
 	}
 }
 
+func TestField_incremental(t *testing.T) {
+	tests := []struct {
+		annotations map[string]interface{}
+		def         bool
+		expected    bool
+	}{
+		{dict("EntSQL", nil), false, false},
+		{dict("EntSQL", nil), true, true},
+		{dict("EntSQL", dict("incremental", true)), false, true},
+		{dict("EntSQL", dict("incremental", false)), true, false},
+	}
+	for _, tt := range tests {
+		typ := &Field{Annotations: tt.annotations}
+		require.Equal(t, tt.expected, typ.incremental(tt.def))
+	}
+}
+
 func TestBuilderField(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/entc/integration/ent/migrate/schema.go
+++ b/entc/integration/ent/migrate/schema.go
@@ -7,6 +7,7 @@
 package migrate
 
 import (
+	"github.com/facebook/ent/dialect/entsql"
 	"github.com/facebook/ent/dialect/sql/schema"
 	"github.com/facebook/ent/schema/field"
 )
@@ -52,6 +53,7 @@ var (
 				Columns: []*schema.Column{CardsColumns[0], CardsColumns[4], CardsColumns[3]},
 			},
 		},
+		Annotation: &entsql.Annotation{Incremental: &[]bool{false}[0]},
 	}
 	// CommentsColumns holds the columns for the "comments" table.
 	CommentsColumns = []*schema.Column{

--- a/entc/integration/ent/schema/card.go
+++ b/entc/integration/ent/schema/card.go
@@ -6,6 +6,7 @@ package schema
 
 import (
 	"github.com/facebook/ent"
+	"github.com/facebook/ent/dialect/entsql"
 	"github.com/facebook/ent/entc/integration/ent/template"
 	"github.com/facebook/ent/schema"
 	"github.com/facebook/ent/schema/edge"
@@ -45,11 +46,16 @@ func (Card) Mixin() []ent.Mixin {
 }
 
 func (Card) Annotations() []schema.Annotation {
+	incrementalEnabled := false
+
 	return []schema.Annotation{
 		field.Annotation{
 			StructTag: map[string]string{
 				"id": `json:"-"`,
 			},
+		},
+		entsql.Annotation{
+			Incremental: &incrementalEnabled,
 		},
 	}
 }


### PR DESCRIPTION
I ran into this issue when I was implementing https://github.com/facebook/ent/pull/1142

when an Annotation value is a pointer, like `*bool Incremental` it was being written to `ent/migate/schema.go` as such, with by `dumpFields` with the string written being the address, which of course doesn't work.

this PR fixes that, I extract it from https://github.com/facebook/ent/pull/1142 because I think it should be merged regardless if #1142 gets accepted.

I went for `boolPtr`, `strPtr`, `intPtr`, but open to any other naming for those functions or we could include the `pointer` library if you don't mind including another dependency.