### PR TITLE
docs: fix link to Annotation interface

### DIFF
--- a/doc/md/schema-annotations.md
+++ b/doc/md/schema-annotations.md
@@ -5,7 +5,7 @@ title: Annotations
 
 Schema annotations allow attaching metadata to schema objects like fields and edges and inject them to external templates.
 An annotation must be a Go type that is serializable to JSON raw value (e.g. struct, map or slice)
-and implement the [Annotation](https://pkg.go.dev/github.com/facebook/ent/schema/field?tab=doc#Annotation) interface.
+and implement the [Annotation](https://pkg.go.dev/github.com/facebook/ent/schema?tab=doc#Annotation) interface.
 
 The builtin annotations allow configuring the different storage drivers (like SQL) and control the code generation output. 
 

--- a/doc/md/templates.md
+++ b/doc/md/templates.md
@@ -71,7 +71,7 @@ In order to override an existing template, use its name. For example:
 ## Annotations
 Schema annotations allow attaching metadata to fields and edges and inject them to external templates.  
 An annotation must be a Go type that is serializable to JSON raw value (e.g. struct, map or slice)
-and implement the [Annotation](https://pkg.go.dev/github.com/facebook/ent/schema/field?tab=doc#Annotation) interface.
+and implement the [Annotation](https://pkg.go.dev/github.com/facebook/ent/schema?tab=doc#Annotation) interface.
 
 Here's an example of an annotation and its usage in schema and template:
 


### PR DESCRIPTION
These links were to the Annotation type in schema/field vs the interface in the schema package.