### PR TITLE
entc/internal: catch syntax error due to conflict marker

### DIFF
--- a/entc/internal/snapshot.go
+++ b/entc/internal/snapshot.go
@@ -218,7 +218,13 @@ func IsBuildError(err error) bool {
 	if strings.HasPrefix(err.Error(), "entc/load: #") {
 		return true
 	}
-	for _, s := range []string{"syntax error", "previous declaration", "invalid character", "could not import"} {
+	for _, s := range []string{
+		"syntax error",
+		"previous declaration",
+		"invalid character",
+		"could not import",
+		"found '<<'",
+	} {
 		if strings.Contains(err.Error(), s) {
 			return true
 		}


### PR DESCRIPTION
A syntax error caused by a conflict marker doesn't get caught by the IsBuildError function, causing Ent not to try and recover using the stored schema snapshot. In this PR we add a check for the substring `found '<<'`.