### PR TITLE
Ensure sqlgraph passes the context to *sql.Selector

### DIFF
--- a/dialect/sql/sqlgraph/graph_test.go
+++ b/dialect/sql/sqlgraph/graph_test.go
@@ -810,7 +810,7 @@ func TestHasNeighborsWithContext(t *testing.T) {
 	ctx := context.WithValue(context.Background(), key("mykey"), "myval")
 	for _, rel := range [...]Rel{M2M, O2M, O2O} {
 		t.Run(rel.String(), func(t *testing.T) {
-			sel := sql.Dialect("postgres").
+			sel := sql.Dialect(dialect.Postgres).
 				Select("*").
 				From(sql.Table("users")).
 				WithContext(ctx)

--- a/dialect/sql/sqlgraph/graph_test.go
+++ b/dialect/sql/sqlgraph/graph_test.go
@@ -805,6 +805,35 @@ WHERE "s1"."users"."id" IN
 	}
 }
 
+func TestHasNeighborsWithContext(t *testing.T) {
+	type key string
+	ctx := context.WithValue(context.Background(), key("mykey"), "myval")
+	for _, rel := range [...]Rel{M2M, O2M, O2O} {
+		t.Run(rel.String(), func(t *testing.T) {
+			sel := sql.Dialect("postgres").
+				Select("*").
+				From(sql.Table("users")).
+				WithContext(ctx)
+			step := NewStep(
+				From("users", "id"),
+				To("groups", "id"),
+				Edge(rel, false, "user_groups", "user_id", "group_id"),
+			)
+			var called bool
+			pred := func(s *sql.Selector) {
+				called = true
+				if got := s.Context().Value(key("mykey")).(string); got != "myval" {
+					t.Fatalf("expected selector context to have %q but got %q", "myval", got)
+				}
+			}
+			HasNeighborsWith(sel, step, pred)
+			if !called {
+				t.Fatal("expected predicate function to be called")
+			}
+		})
+	}
+}
+
 func TestCreateNode(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/dialect/sql/sqlgraph/graph_test.go
+++ b/dialect/sql/sqlgraph/graph_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/facebook/ent/dialect"
 	"github.com/facebook/ent/dialect/sql"
 	"github.com/facebook/ent/schema/field"
 
@@ -823,7 +824,7 @@ func TestHasNeighborsWithContext(t *testing.T) {
 			pred := func(s *sql.Selector) {
 				called = true
 				got := s.Context().Value(key("mykey")).(string)
-				require.Equal(t,  "myval" , got)
+				require.Equal(t, "myval", got)
 			}
 			HasNeighborsWith(sel, step, pred)
 			require.True(t, called, "expected predicate function to be called")

--- a/dialect/sql/sqlgraph/graph_test.go
+++ b/dialect/sql/sqlgraph/graph_test.go
@@ -822,14 +822,11 @@ func TestHasNeighborsWithContext(t *testing.T) {
 			var called bool
 			pred := func(s *sql.Selector) {
 				called = true
-				if got := s.Context().Value(key("mykey")).(string); got != "myval" {
-					t.Fatalf("expected selector context to have %q but got %q", "myval", got)
-				}
+				got := s.Context().Value(key("mykey")).(string)
+				require.Equal(t,  "myval" , got)
 			}
 			HasNeighborsWith(sel, step, pred)
-			if !called {
-				t.Fatal("expected predicate function to be called")
-			}
+			require.True(t, called, "expected predicate function to be called")
 		})
 	}
 }


### PR DESCRIPTION
This PR ensures that sqlgraph functions that receive a context and create a selector will make sure to pass the context to said selector so that future predicate functions can extract data relevant to them. 

Updates https://github.com/facebook/ent/issues/663