### PR TITLE
Add sql/schemaconfig feature flag

### DIFF
--- a/entc/gen/feature.go
+++ b/entc/gen/feature.go
@@ -43,11 +43,25 @@ var (
 		},
 	}
 
+	// FeatureCustomSchemas allows users to pass init time alternate schema names
+	// for each ent model. This is useful if your SQL tables are spread out against
+	// multiple databases.
+	FeatureCustomSchemas = Feature{
+		Name:        "sql/schemaconfig",
+		Stage:       Experimental,
+		Default:     false,
+		Description: "Allows alternate schema names for each ent model. Useful if SQL tables are spread out against multiple databases",
+		cleanup: func(c *Config) error {
+			return os.RemoveAll(filepath.Join(c.Target, "internal"))
+		},
+	}
+
 	// AllFeatures holds a list of all feature-flags.
 	AllFeatures = []Feature{
 		FeaturePrivacy,
 		FeatureEntQL,
 		FeatureSnapshot,
+		FeatureCustomSchemas,
 	}
 )
 


### PR DESCRIPTION
Adds the feature flag option to expose alternate schema names (which at this point doesn't do anything yet)

Updates https://github.com/facebook/ent/issues/663