### PR TITLE
[bug] using .Total() in builder.Join results in wrong count

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -2221,10 +2221,7 @@ func (b *Builder) join(qs []Querier, sep string) *Builder {
 		query, args := q.Query()
 		b.WriteString(query)
 		b.args = append(b.args, args...)
-		b.total = len(b.args)
-		if ok {
-			b.total = st.Total()
-		}
+		b.total += len(args)
 	}
 	return b
 }

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1371,6 +1371,24 @@ WHERE
 			wantQuery: "SELECT * FROM `users` JOIN `pets` AS `t0` ON `users`.`id` = `t0`.`owner_id` WHERE `t0`.`name` = ?",
 			wantArgs:  []interface{}{"pedro"},
 		},
+		{
+			input: func() Querier {
+				t1 := Table("users")
+				sel := Select("*").
+					From(t1).
+					Where(P(func(b *Builder) {
+						b.Join(Expr("name = $1", "pedro"))
+					})).
+					Where(P(func(b *Builder) {
+						b.Join(Expr("name = $2", "pedro"))
+					})).
+					Where(EQ("name", "pedro"))
+				sel.SetDialect(dialect.Postgres)
+				return sel
+			}(),
+			wantQuery: `SELECT * FROM "users" WHERE (name = $1 AND name = $2) AND "name" = $3`,
+			wantArgs:  []interface{}{"pedro", "pedro", "pedro"},
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -1379,6 +1397,25 @@ WHERE
 			require.Equal(t, tt.wantArgs, args)
 		})
 	}
+}
+
+func TestAnd(t *testing.T) {
+	assert := require.New(t)
+
+	p1 := P(func(b *Builder) {
+		b.Join(Expr("name = $1", "pedro"))
+	})
+	p2 := P(func(b *Builder) {
+		b.Join(Expr("name = $2", "pedro"))
+	})
+
+	and := And(p1, p2)
+
+	_, _ = and.Query()
+
+	assert.Equal(1, p1.Total())
+	assert.Equal(2, p2.Total())
+	assert.Equal(2, and.Total())
 }
 
 func TestBuilder_Err(t *testing.T) {


### PR DESCRIPTION
Opening this PR to demonstrate something which I think is a bug.  
It also includes a fix, but I can't say with 100% certainty this is the right fix.

I was using the `sql.Expr` to construct some custom query stuff and noticed that there was something wrong with the parameter numbering in postgres.

there's 2 tests to demonstrate the issue, both fail when the `b.total = st.Total()` is left in place.

the problem seems to be that without the `b.total = st.Total()` we loose the previously set `.SetTotal`, but with it it will reset it when we're doing nested predicates.  
I think my fix will work in both cases, and all tests pass ... 