### PR TITLE
doc: fix github link

### DIFF
--- a/doc/md/code-gen.md
+++ b/doc/md/code-gen.md
@@ -140,7 +140,7 @@ func main() {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/entcpkg).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/entcpkg).
 
 
 ## Schema Description

--- a/doc/md/getting-started.md
+++ b/doc/md/getting-started.md
@@ -610,4 +610,4 @@ Now when we have a graph with data, we can run a few queries on it:
     }
     ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/start).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/start).

--- a/doc/md/privacy.md
+++ b/doc/md/privacy.md
@@ -264,7 +264,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/privacyadmin).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/privacyadmin).
 
 ### Multi Tenancy
 
@@ -273,7 +273,7 @@ The helper packages `viewer` and `rule` (as mentioned above) also exist in this 
 
 ![tenant-example](https://s3.eu-central-1.amazonaws.com/entgo.io/assets/tenant_medium.png)
 
-Let's start building this application piece by piece. We begin by creating 3 different schemas (see the full code [here](https://entgo.io/ent/tree/master/examples/privacytenant/ent/schema)),
+Let's start building this application piece by piece. We begin by creating 3 different schemas (see the full code [here](https://github.com/facebook/ent/tree/master/examples/privacytenant/ent/schema)),
 and since we want to share some logic between them, we create another [mixed-in schema](schema-mixin.md) and add it to all other schemas as follows:
 
 ```go
@@ -562,6 +562,6 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/privacytenant).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/privacytenant).
 
 Please note that this documentation is under active development.

--- a/doc/md/schema-edges.md
+++ b/doc/md/schema-edges.md
@@ -252,7 +252,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2o2types).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2o2types).
 
 ## O2O Same Type
 
@@ -348,7 +348,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2orecur).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2orecur).
 
 ## O2O Bidirectional
 
@@ -422,7 +422,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2obidi).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2obidi).
 
 ## O2M Two Types
 
@@ -503,7 +503,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 	return nil
 }
 ```
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2m2types).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2m2types).
 
 ## O2M Same Type
 
@@ -612,7 +612,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2mrecur).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2mrecur).
 
 ## M2M Two Types
 
@@ -704,7 +704,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/m2m2types).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/m2m2types).
 
 ## M2M Same Type
 
@@ -797,7 +797,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/m2mrecur).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/m2mrecur).
 
 
 ## M2M Bidirectional
@@ -860,7 +860,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/m2mbidi).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/m2mbidi).
 
 ## Required
 

--- a/doc/md/schema-indexes.md
+++ b/doc/md/schema-indexes.md
@@ -147,7 +147,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/edgeindex).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/edgeindex).
 
 ## Dialect Support
 

--- a/doc/md/transactions.md
+++ b/doc/md/transactions.md
@@ -58,7 +58,7 @@ func rollback(tx *ent.Tx, err error) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/traversal).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/traversal).
 
 ## Transactional Client
 
@@ -88,7 +88,7 @@ func Gen(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/traversal).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/traversal).
 
 ## Best Practices
 

--- a/doc/md/traversals.md
+++ b/doc/md/traversals.md
@@ -213,4 +213,4 @@ func Traverse(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/traversal).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/traversal).

--- a/examples/README.md
+++ b/examples/README.md
@@ -222,7 +222,7 @@ func Traverse(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/traversal).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/traversal).
 
 
 ## Relationship
@@ -304,7 +304,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2o2types).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2o2types).
 
 ## O2O Same Type
 
@@ -400,7 +400,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2o2recur).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2o2recur).
 
 ## O2O Bidirectional
 
@@ -474,7 +474,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2obidi).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2obidi).
 
 ## O2M Two Types
 
@@ -555,7 +555,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 	return nil
 }
 ```
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2m2types).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2m2types).
 
 ## O2M Same Type
 
@@ -664,7 +664,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/o2mrecur).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/o2mrecur).
 
 ## M2M Two Types
 
@@ -756,7 +756,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/m2m2types).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/m2m2types).
 
 ## M2M Same Type
 
@@ -849,7 +849,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/m2mrecur).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/m2mrecur).
 
 
 ## M2M Bidirectional
@@ -912,7 +912,7 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/m2mbidi).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/m2mbidi).
 
 ## Indexes
 
@@ -1020,5 +1020,5 @@ func Do(ctx context.Context, client *ent.Client) error {
 }
 ```
 
-The full example exists in [GitHub](https://entgo.io/ent/tree/master/examples/edgeindex).
+The full example exists in [GitHub](https://github.com/facebook/ent/tree/master/examples/edgeindex).
 


### PR DESCRIPTION
I was happily reading ent documentation site and found that the link to github was broken

`https://entgo.io/ent/tree/master/examples/ `-> `https://github.com/facebook/ent/tree/master/examples/`