### PR TITLE
entc: add extra name check for private identifiers

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -694,6 +694,9 @@ func ValidSchemaName(name string) error {
 	if _, ok := globalIdent[name]; ok {
 		return fmt.Errorf("schema name conflicts with ent predeclared identifier %q", name)
 	}
+	if _, ok := privateField[pkg]; ok {
+		return fmt.Errorf("schema name conflicts with ent builder fields %q", pkg)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #1225 

Supplementary to #1110 

Adds checks for schema names against private identifiers when running codegen and using `ent init`

![image](https://user-images.githubusercontent.com/8946502/107009569-579ed500-67e9-11eb-8dbe-aefb711897c9.png)
![image](https://user-images.githubusercontent.com/8946502/107009587-5cfc1f80-67e9-11eb-90d3-2f1ae131709b.png)
