### PR TITLE
chore: reduce funlen

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters-settings:
   dupl:
     threshold: 100
   funlen:
-    lines: 130
+    lines: 100
     statements: 80
   goheader:
     template: |-


### PR DESCRIPTION
Now that the problematic function has been excluded - https://github.com/facebook/ent/blob/dd4792f5b30bdd2db0d9a593a977a54cb3f0c1ce/entc/integration/ent/schema/fieldtype.go#L31

The funlen can be reduced to its original size